### PR TITLE
some fixes to the formatter and it now also can process raw input into json

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+*.sh            text eol=lf
+*.php           text eol=lf
+*.inc           text eol=lf
+*.html          text eol=lf
+*.js            text eol=lf
+*.css           text eol=lf
+*.ini           text eol=lf
+*.txt           text eol=lf
+*.xml           text eol=lf
+*.md            text eol=lf
+*.markdown      text eol=lf
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Apple MAC cruft
+.DS_Store
+
+# Editor backup files
+*.bak
+*~

--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,50 @@
+########################################
+# Locale settings
+########################################
+
+# See: http://php.net/manual/en/timezones.php
+php_value date.timezone "Europe/Amsterdam"
+
+SetEnv   LC_ALL  nl_NL.UTF-8
+
+########################################
+# Set up UTF-8 encoding
+########################################
+
+AddDefaultCharset UTF-8
+AddCharset UTF-8 .php
+
+php_value default_charset "UTF-8"
+
+php_value iconv.input_encoding "UTF-8"
+php_value iconv.internal_encoding "UTF-8"
+php_value iconv.output_encoding "UTF-8"
+
+php_value mbstring.internal_encoding UTF-8
+php_value mbstring.http_output UTF-8
+php_value mbstring.encoding_translation On
+php_value mbstring.func_overload 6
+
+# See also php functions:
+# mysql_set_charset
+# mysql_client_encoding
+
+# database settings
+#CREATE DATABASE db_name
+#   CHARACTER SET utf8
+#   DEFAULT CHARACTER SET utf8
+#   COLLATE utf8_general_ci
+#   DEFAULT COLLATE utf8_general_ci
+#   ;
+#
+#ALTER DATABASE db_name
+#   CHARACTER SET utf8
+#   DEFAULT CHARACTER SET utf8
+#   COLLATE utf8_general_ci
+#   DEFAULT COLLATE utf8_general_ci
+#   ;
+
+#ALTER TABLE tbl_name
+#   DEFAULT CHARACTER SET utf8
+#   COLLATE utf8_general_ci
+#   ;

--- a/example-1.php
+++ b/example-1.php
@@ -1,0 +1,9 @@
+<?
+
+require_once("nicejson.php");
+
+// Example usage (use php-cli)
+$file = dirname(__FILE__).'/example.json';
+$json = file_get_contents($file);
+print_r(json_format($json));
+

--- a/example-1.php
+++ b/example-1.php
@@ -1,9 +1,35 @@
-<?
+<?php
+
+//                     WARNING
+//
+// this example needs the .htaccess included in this repo 
+// as per http://stackoverflow.com/questions/6987929/preparing-php-application-to-use-with-utf-8
+// or the Japanese Unicode characters in the example JSON file 
+// won't make it through the ordeal alive!
 
 require_once("nicejson.php");
 
-// Example usage (use php-cli)
-$file = dirname(__FILE__).'/example.json';
+
+
+header('content-type: text/html; charset: utf-8');
+echo <<<EOT
+<html>
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8">
+</head>
+<body>
+  <h1>JSON dump</h1>
+  <pre>
+EOT;
+
+// Example usage 
+
+
+$file = dirname(__FILE__) . '/example.json';
 $json = file_get_contents($file);
-print_r(json_format($json));
+// strip off optional Unicode BOM:
+if (substr($json, 0, 3) == "\xEF\xBB\xBF") {
+  $json = substr($json, 3);
+}
+echo htmlspecialchars(json_format($json));
 

--- a/example.json
+++ b/example.json
@@ -1,1 +1,1 @@
-﻿{"hey": "guy","anumber": 243,"anobject": {"whoa": "nuts","anarray": [1,2,"thr<h1>ee"], "more":"stuff"},"awesome": true,"bogus": false,"meaning": null, "japanese":"明日がある。", "link": "http://jsonview.com", "notLink": "http://jsonview.com is great"}
+﻿{"hey": "guy","anumber": 243,"anobject": {"whoa": "nuts","anarray": [1,2,"thr<h1>ee"], "more":"stuff"},"awesome": true,"bogus": false,"meaning": null, "japanese":"明日がある。", "link": "http://jsonview.com", "notLink": "http://jsonview.com is great", "colon-ed-item":"text: \"that was a colon!\""}

--- a/nicejson.php
+++ b/nicejson.php
@@ -1,4 +1,5 @@
-<?
+<?php
+
 /**
 * Formate a flat JSON string to make it more human-readable
 *
@@ -52,7 +53,3 @@ function json_format($json)
   return $result;
 }
 
-// Example usage (use php-cli)
-$file = dirname(__FILE__).'/example.json';
-$json = file_get_contents($file);
-print_r(json_format($json));

--- a/nicejson.php
+++ b/nicejson.php
@@ -25,10 +25,10 @@ function json_format($json)
     }
     // If this character is the end of an element, 
     // output a new line and indent the next line
-    else if(($char == '}' || $char == ']') && $outOfQuotes) {
+    else if (($char == '}' || $char == ']') && $outOfQuotes) {
       $result .= $newLine;
       $pos--;
-      for ($j=0; $j<$pos; $j++) {
+      for ($j = 0; $j < $pos; $j++) {
         $result .= $indentStr;
       }
     }

--- a/nicejson.php
+++ b/nicejson.php
@@ -4,7 +4,7 @@
 // adapted to allow native functionality in php version >= 5.4.0
 
 /**
-* Formate a flat JSON string to make it more human-readable
+* Format a flat JSON string to make it more human-readable
 *
 * @param string $json The original JSON string to process
 *        When the input is not a string it is assumed the input is RAW
@@ -44,7 +44,7 @@ function json_format($json) {
       }
     }
     // eat all non-essential whitespace in the input as we do our own here and it would only mess up our process
-    else if (false !== strpos(" \t\r\n", $char)) {
+    else if ($outOfQuotes && false !== strpos(" \t\r\n", $char)) {
       continue;
     }
 

--- a/nicejson.php
+++ b/nicejson.php
@@ -19,7 +19,7 @@ function json_format($json) {
     $json = json_encode($json);
   }
   $result      = '';
-  $pos         = 0;
+  $pos         = 0;               // indentation level
   $strLen      = strlen($json);
   $indentStr   = '  ';
   $newLine     = "\n";
@@ -43,8 +43,17 @@ function json_format($json) {
         $result .= $indentStr;
       }
     }
+    // eat all non-essential whitespace in the input as we do our own here and it would only mess up our process
+    else if (false !== strpos(" \t\r\n", $char)) {
+      continue;
+    }
+
     // Add the character to the result string
     $result .= $char;
+    // always add a space after a field colon:
+    if ($char == ':' && $outOfQuotes) {
+      $result .= ' ';
+    }
 
     // If the last character was the beginning of an element,
     // output a new line and indent the next line

--- a/nicejson.php
+++ b/nicejson.php
@@ -1,30 +1,40 @@
 <?php
 
+// original code: http://www.daveperrett.com/articles/2008/03/11/format-json-with-php/
+// adapted to allow native functionality in php version >= 5.4.0
+
 /**
 * Formate a flat JSON string to make it more human-readable
 *
 * @param string $json The original JSON string to process
+*        When the input is not a string it is assumed the input is RAW
+*        and should be converted to JSON first of all.
 * @return string Indented version of the original JSON string
 */
-function json_format($json)
-{
-  $result = '';
-  $pos = 0;
-  $strLen = strlen($json);
-  $indentStr = ' ';
-  $newLine = "\n";
-  $prevChar = '';
+function json_format($json) {
+  if (phpversion() && phpversion() >= 5.4) {
+    return json_encode($json, JSON_PRETTY_PRINT);
+  }
+  if (!is_string($json)) {
+    $json = json_encode($json);
+  }
+  $result      = '';
+  $pos         = 0;
+  $strLen      = strlen($json);
+  $indentStr   = '  ';
+  $newLine     = "\n";
+  $prevChar    = '';
   $outOfQuotes = true;
-  
+
   for ($i = 0; $i <= $strLen; $i++) {
     // Grab the next character in the string
     $char = substr($json, $i, 1);
-    
+
     // Are we inside a quoted string?
     if ($char == '"' && $prevChar != '\\') {
       $outOfQuotes = !$outOfQuotes;
     }
-    // If this character is the end of an element, 
+    // If this character is the end of an element,
     // output a new line and indent the next line
     else if (($char == '}' || $char == ']') && $outOfQuotes) {
       $result .= $newLine;
@@ -36,7 +46,7 @@ function json_format($json)
     // Add the character to the result string
     $result .= $char;
 
-    // If the last character was the beginning of an element, 
+    // If the last character was the beginning of an element,
     // output a new line and indent the next line
     if (($char == ',' || $char == '{' || $char == '[') && $outOfQuotes) {
       $result .= $newLine;

--- a/nicejson.php
+++ b/nicejson.php
@@ -21,7 +21,7 @@ function json_format($json) {
   $result      = '';
   $pos         = 0;               // indentation level
   $strLen      = strlen($json);
-  $indentStr   = '  ';
+  $indentStr   = "\t";
   $newLine     = "\n";
   $prevChar    = '';
   $outOfQuotes = true;

--- a/nicejson.php
+++ b/nicejson.php
@@ -12,10 +12,10 @@
 * @return string Indented version of the original JSON string
 */
 function json_format($json) {
-  if (phpversion() && phpversion() >= 5.4) {
-    return json_encode($json, JSON_PRETTY_PRINT);
-  }
   if (!is_string($json)) {
+    if (phpversion() && phpversion() >= 5.4) {
+      return json_encode($json, JSON_PRETTY_PRINT);
+    }
     $json = json_encode($json);
   }
   $result      = '';

--- a/nicejson.php
+++ b/nicejson.php
@@ -26,7 +26,7 @@ function json_format($json) {
   $prevChar    = '';
   $outOfQuotes = true;
 
-  for ($i = 0; $i <= $strLen; $i++) {
+  for ($i = 0; $i < $strLen; $i++) {
     // Grab the next character in the string
     $char = substr($json, $i, 1);
 


### PR DESCRIPTION
see the commit chain; when you feed it raw data (object tree or array...) as input PHP 5.4 default json pretty printing can be used when available; otherwise you get the same result using the custom code, which has been fixed to always use the same amount of whitespace irrespective of the exact amount available in the input (string or raw).
